### PR TITLE
OSW-1252

### DIFF
--- a/rubin_nights/influx_query.py
+++ b/rubin_nights/influx_query.py
@@ -209,6 +209,7 @@ class InfluxQueryClient:
                 params=params,
             )
             response.raise_for_status()
+            logger.debug(f"Issued query: {params['q']}")
         except Exception as e:
             logger.warning(e)
             response = None
@@ -222,8 +223,6 @@ class InfluxQueryClient:
             result = []
             if self.results_as_dataframe:
                 result = pd.DataFrame(result)
-        if len(result) == 0:
-            logging.debug(f"Query {params['q']} produced no results.")
 
         return result
 
@@ -236,6 +235,7 @@ class InfluxQueryClient:
                 params=params,
             )
             response.raise_for_status()
+            logger.debug(f"Issued query: {params['q']}")
         except Exception as e:
             logger.warning(e)
             response = None
@@ -249,8 +249,6 @@ class InfluxQueryClient:
             result = []
             if self.results_as_dataframe:
                 result = pd.DataFrame(result)
-        if len(result) == 0:
-            logging.debug(f"Query {params['q']} produced no results.")
 
         return result
 

--- a/rubin_nights/scriptqueue.py
+++ b/rubin_nights/scriptqueue.py
@@ -798,7 +798,7 @@ def get_narrative_and_errors(
     obs_status_messages.rename(
         {"note": "description", "statusLabels": "name", "status": "script_salIndex"}, axis=1, inplace=True
     )
-    obs_status_messages["category_index"] = CategoryIndexExtended.NARRATIVE_LOG_SIMONYI.value
+    obs_status_messages["category_index"] = CategoryIndexExtended.OBSERVATORY_STATUS_SIMONYI.value
     obs_status_messages["config"] = "LOVE"
     obs_status_messages["finalStatus"] = "ObsStatus"
     obs_status_messages["timestampProcessStart"] = obs_status_messages.index.values.copy()
@@ -821,7 +821,11 @@ def get_narrative_and_errors(
         tracebacks = pd.DataFrame([])
     # Merge
     df_list = [messages, obs_status_messages, errs, tracebacks]
-    narrative_and_errors = pd.concat([df for df in df_list if not df.empty]).sort_index()
+    df_to_concat = [df for df in df_list if not df.empty]
+    if len(df_to_concat) > 0:
+        narrative_and_errors = pd.concat(df_to_concat).sort_index()
+    else:
+        narrative_and_errors = pd.DataFrame([])
     return narrative_and_errors
 
 

--- a/rubin_nights/scriptqueue.py
+++ b/rubin_nights/scriptqueue.py
@@ -739,6 +739,7 @@ def get_narrative_and_errors(
     t_end: Time,
     efd_client: InfluxQueryClient,
     narrative_log_client: NarrativeLogClient,
+    fetch_errors: bool = True,
     all_tracebacks: bool = True,
 ) -> pd.DataFrame:
     """Get narrative log and error code messages.
@@ -753,9 +754,12 @@ def get_narrative_and_errors(
         EfdClient to query the efd.
     narrative_log_client
         Narrative log query client.
+    fetch_errors
+        Fetch error messages and codes from CSCs with an error code topic.
     all_tracebacks
         Flag as to whether to query for all tracebacks from systems other
-        than lsst.sal.Script.logevent_logMessages.
+        than lsst.sal.Script.logevent_logMessages (included previously with
+        scriptqueue outputs).
 
     Returns
     -------
@@ -809,7 +813,20 @@ def get_narrative_and_errors(
     logger.info(f"Found {len(obs_status_messages)} entries from observatoryStatus")
 
     # Get error codes
-    errs = get_error_codes(t_start, t_end, efd_client)
+    if fetch_errors:
+        errs = get_error_codes(t_start, t_end, efd_client)
+    else:
+        errs = pd.DataFrame(
+            [],
+            columns=[
+                "name",
+                "errorReport",
+                "config",
+                "category_index",
+                "errorCode" "finalStatus",
+                "timestampProcessStart",
+            ],
+        )
     if len(errs) > 0:
         # Rename some columns to match narrative log columns
         errs.rename(
@@ -983,7 +1000,7 @@ def get_exposure_info(
 
 
 def get_consolidated_messages(
-    t_start: Time, t_end: Time, endpoints: dict, all_tracebacks: bool = False
+    t_start: Time, t_end: Time, endpoints: dict, fetch_errors: bool = True, all_tracebacks: bool = False
 ) -> tuple[pd.DataFrame, list[str]]:
     """Get consolidated messages from EFD ScriptQueue, errorCodes,
     CCCamera, exposure and narrative logs.
@@ -999,8 +1016,11 @@ def get_consolidated_messages(
         ConsDb, such as returned by `rubin_nights.connections.get_clients`.
         Must have clients for the `efd`, `obsenv`, `narrative_log` and
         `exposure_log`.
+    fetch_errors
+        Fetch error messages from all available CSCs.
     all_tracebacks
-        If True, get all tracebacks, else get only Script tracebacks.
+        Flag as to whether to query for all tracebacks from systems other
+        than lsst.sal.Script.logevent_logMessages (which is always included).
 
     Returns
     -------
@@ -1045,7 +1065,12 @@ def get_consolidated_messages(
 
     # columns from narrative and errors
     narrative_and_errs = get_narrative_and_errors(
-        t_start, t_end, endpoints["efd"], endpoints["narrative_log"], all_tracebacks
+        t_start,
+        t_end,
+        endpoints["efd"],
+        endpoints["narrative_log"],
+        fetch_errors=fetch_errors,
+        all_tracebacks=all_tracebacks,
     )
 
     # columns from images_and_logs

--- a/rubin_nights/scriptqueue.py
+++ b/rubin_nights/scriptqueue.py
@@ -279,7 +279,9 @@ def get_script_stream(t_start: Time, t_end: Time, efd_client: InfluxQueryClient)
     topic = "lsst.sal.Script.logevent_description"
     fields = ["classname", "description", "salIndex"]
     scriptdescription: pd.DataFrame = efd_client.select_time_series(topic, fields, t_start, t_end)
-    scriptdescription.rename({"salIndex": "script_salIndex"}, axis=1, inplace=True)
+    scriptdescription.rename(
+        {"salIndex": "script_salIndex", "classname": "script_name"}, axis=1, inplace=True
+    )
 
     # This gets us more information about the script parameters,
     # how they were configured
@@ -526,6 +528,8 @@ def get_script_status(t_start: Time, t_end: Time, efd_client: InfluxQueryClient)
                 )
         # Convert to a single dataframe
         script_status = pd.concat(script_status)
+    # Modify path to classname here, to match other definintions
+    script_status.rename({"path": "classname"}, axis=1, inplace=True)
 
     logger.info(f"Found {len(script_status)} script status messages")
 

--- a/rubin_nights/scriptqueue.py
+++ b/rubin_nights/scriptqueue.py
@@ -757,6 +757,7 @@ def get_narrative_and_errors(
     -------
     narrative_and_errors : `pd.DataFrame`
     """
+    # Get and rename the narrative log
     messages = narrative_log_client.query_log(t_start, t_end)
     # Modify narrative log content
     if len(messages) > 0:
@@ -778,7 +779,11 @@ def get_narrative_and_errors(
                 st = "Log"
             return st
 
+        def strip_user_id_at_part(x: pd.Series) -> str:
+            return x.user_id.split("@")[0]
+
         messages["finalStatus"] = messages.apply(build_status, axis=1)
+        messages["user_id"] = messages.apply(strip_user_id_at_part, axis=1)
         messages.rename(
             {"component": "name", "user_id": "config", "message_text": "description"}, axis=1, inplace=True
         )

--- a/rubin_nights/scriptqueue_formatting.py
+++ b/rubin_nights/scriptqueue_formatting.py
@@ -18,6 +18,7 @@ def get_name_and_color_from_category_index(
         CategoryIndexExtended.NARRATIVE_LOG_OTHER.value: ("Narrative log", "#cf7ddc"),
         CategoryIndexExtended.NARRATIVE_LOG_SIMONYI.value: ("Narrative log MT", "#cf7ddc"),
         CategoryIndexExtended.NARRATIVE_LOG_AUX.value: ("Narrative log AT", "#cf7ddc"),
+        CategoryIndexExtended.OBSERVATORY_STATUS_SIMONYI.value: ("Observatory Status MT", "#cf7ddc"),
         CategoryIndexExtended.MAIN_TEL.value: ("MTQueue", "#b4c546"),
         CategoryIndexExtended.AUX_TEL.value: ("ATQueue", "#bab980"),
         CategoryIndexExtended.OCS.value: ("OCSQueue", "#b2baad"),

--- a/rubin_nights/ts_xml_enums.py
+++ b/rubin_nights/ts_xml_enums.py
@@ -88,6 +88,7 @@ class CategoryIndexExtended(enum.IntEnum):
     NARRATIVE_LOG_SIMONYI = 20
     NARRATIVE_LOG_AUX = 21
     NARRATIVE_LOG_OTHER = 22
+    OBSERVATORY_STATUS_SIMONYI = 23
 
 
 def apply_enum(x: pd.Series, column: str, enumvals: ScriptState | CSCState) -> str:


### PR DESCRIPTION
Sorry for the combo-problem PR, but they were in the same section of code .. and they're all relevant to your interests @alserene .

* removes the "@" from the user-name in the narrative log,  
* uses the filepath for the script instead of the name of the script
* adds the observatory status as an additional category index,

Perhaps more aggregious to include in the same spot, but they're very few lines of code and still impact the context feed  ..  given the current concern about number of EFD queries at the summit, I did also do a bit of spelunking and 
* added a debug option to track the number of EFD queries
* added a flag that would let you turn off the bulk of the queries related to the context feed (the queries that fetch the error messages).

The default behavior of the consolidated messages from get_consolidated_messages should be generally the same as what you expect at present. The additional category index I think would just get dropped at the nightly digest level, and the kwargs for the other flags remain the same.  The string values for the narrative log username and the classname for the scripts change, but these are just different strings than they were previously. 