### PR TITLE
SP-3078: add repertoire authentication and ID string to influx client

### DIFF
--- a/rubin_nights/connections.py
+++ b/rubin_nights/connections.py
@@ -11,8 +11,10 @@ __all__ = ["get_access_token", "get_clients", "usdf_lfa"]
 
 logger = logging.getLogger(__name__)
 
+DEFAULT_TOKENFILE = "usdf_rsp"
 
-def get_access_token(tokenfile: str | None = None, default_tokenfile: str = "usdf_rsp") -> str:
+
+def get_access_token(tokenfile: str | None = None) -> str:
     """Retrieve RSP access token.
 
     Parameters
@@ -23,16 +25,13 @@ def get_access_token(tokenfile: str | None = None, default_tokenfile: str = "usd
         The token will be read from the tokenfile if available.
         If tokenfile is None, then further attempts will be made to
         access the token value from:
-        `lsst.rsp.get_access_token`
-        the environment variable "ACCESS_TOKEN"
-        the environment variable "ACCESS_TOKEN_FILE"
-        the home directory + '.lsst' + default_root
+        * `lsst.rsp.get_access_token`
+        * the environment variable "ACCESS_TOKEN"
+        * the environment variable "ACCESS_TOKEN_FILE"
+        * the home directory + '.lsst' + DEFAULT_TOKENFILE
         If no RSP token is available, access to most services will not
         be available.
-    default_tokenfile
-        If token information is not available from the options above,
-        this defines the default filename on disk to search for in
-        user home directory / .lsst / <default_tokenfile>.
+
 
     Returns
     -------
@@ -81,7 +80,7 @@ def get_access_token(tokenfile: str | None = None, default_tokenfile: str = "usd
         # Fifth - try a default home directory location.
         if token is None:
             logger.debug("$ACCESS_TOKEN_FILE not set.")
-            tokenfile = os.path.join(os.path.expanduser("~"), ".lsst", default_tokenfile)
+            tokenfile = os.path.join(os.path.expanduser("~"), ".lsst", DEFAULT_TOKENFILE)
             logger.debug(f"Checking {tokenfile}")
             # Try to read this, but an error is not an exception.
             try:
@@ -102,7 +101,7 @@ def get_clients(
     site: str | None = None,
     auth_token: str | None = None,
 ) -> dict:
-    """Return site-specific client connections.
+    """Return a wide set of site-specific client connections.
 
     Parameters
     ----------
@@ -167,16 +166,21 @@ def get_clients(
         raise ValueError(f"Site {site} must be in {list(API_ENDPOINTS.keys())}")
 
     api_base = API_ENDPOINTS[site]
+
     narrative_log = NarrativeLogClient(api_base, auth)
     exposure_log = ExposureLogClient(api_base, auth)
     night_report = NightReportClient(api_base, auth)
+
     consdb_query = ConsDbFastAPI(api_base, auth)
     consdb_tap = ConsDbTap(api_base, token=token)
-    efd_client = InfluxQueryClient(site, db_name="efd")
-    obsenv_client = InfluxQueryClient(site, db_name="lsst.obsenv")
+
+    # We'll pass along the auth for the InfluxQueryClients
+    # although there's still work to be done on auth + service site.
+    efd_client = InfluxQueryClient(site, db_name="efd", auth=auth)
+    obsenv_client = InfluxQueryClient(site, db_name="lsst.obsenv", auth=auth)
     # Some special clients that are site-agnostic (only one location)
     too_client = InfluxQueryClient("summit", db_name="lsst.scimma")
-    dm_client = InfluxQueryClient("usdfdev", db_name="lsst.dm")
+    pp_client = InfluxQueryClient("usdf-dev", db_name="lsst.prompt", auth=auth)
 
     # Be extra helpful with environment variables if using USDF for LFA
     if "usdf" in site:
@@ -193,8 +197,8 @@ def get_clients(
         "api_base": api_base,
         "efd": efd_client,
         "obsenv": obsenv_client,
+        "pp": pp_client,
         "too": too_client,
-        "dm": dm_client,
         "consdb": consdb_query,
         "consdb_tap": consdb_tap,
         "narrative_log": narrative_log,

--- a/rubin_nights/connections.py
+++ b/rubin_nights/connections.py
@@ -21,14 +21,16 @@ def get_access_token(tokenfile: str | None = None) -> str:
     ----------
     tokenfile
         Path to the RSP token file. See documentation on RSP tokens at
-        https://rsp.lsst.io/v/usdfprod/guides/auth/creating-user-tokens.html
+        https://rsp.lsst.io/guides/auth/creating-user-tokens.html
         The token will be read from the tokenfile if available.
         If tokenfile is None, then further attempts will be made to
         access the token value from:
-        * `lsst.rsp.get_access_token`
-        * the environment variable "ACCESS_TOKEN"
-        * the environment variable "ACCESS_TOKEN_FILE"
-        * the home directory + '.lsst' + DEFAULT_TOKENFILE
+
+        1. `lsst.rsp.get_access_token`
+        2. the environment variable "ACCESS_TOKEN"
+        3. the environment variable "ACCESS_TOKEN_FILE"
+        4. the home directory + '.lsst' + DEFAULT_TOKENFILE
+
         If no RSP token is available, access to most services will not
         be available.
 

--- a/rubin_nights/connections.py
+++ b/rubin_nights/connections.py
@@ -180,9 +180,9 @@ def get_clients(
     # although there's still work to be done on auth + service site.
     efd_client = InfluxQueryClient(site, db_name="efd", auth=auth)
     obsenv_client = InfluxQueryClient(site, db_name="lsst.obsenv", auth=auth)
+    pp_client = InfluxQueryClient(site, db_name="lsst.prompt", auth=auth)
     # Some special clients that are site-agnostic (only one location)
     too_client = InfluxQueryClient("summit", db_name="lsst.scimma")
-    pp_client = InfluxQueryClient("usdf-dev", db_name="lsst.prompt", auth=auth)
 
     # Be extra helpful with environment variables if using USDF for LFA
     if "usdf" in site:

--- a/rubin_nights/influx_query.py
+++ b/rubin_nights/influx_query.py
@@ -341,7 +341,7 @@ class InfluxQueryClient:
         result : `dict` or `pd.DataFrame`
         """
 
-        params = {"db": self.db_name, "q": query}
+        params = {"db": self.db_name, "q": query + self.query_tag}
         try:
             response = await self.async_client.get(
                 "/query",

--- a/rubin_nights/influx_query.py
+++ b/rubin_nights/influx_query.py
@@ -32,8 +32,8 @@ class InfluxQueryClient:
     site
         The site to use for the EFD, e.g. usdf, summit, base.
         Note that influxdb sites can be special: e.g. currently
-        the EFD at USDF is only on usdf-rsp (not -dev) and
-        Sasquatch (PP metrics) is only at usdf-rsp-dev.
+        the EFD at USDF is only on usdf-rsp (usdf, not -dev) and
+        Sasquatch (PP metrics) is only at usdf-rsp-dev (usdf-dev).
     db_name
         The database to query.
         Not used for credentials info, but will be used to help guide to the
@@ -107,7 +107,14 @@ class InfluxQueryClient:
         self.async_client = httpx.AsyncClient(base_url=self.url, timeout=timeout, auth=influx_auth)
 
     def _fetch_credentials_repertoire(self, auth: tuple) -> tuple[str, tuple[str, bytes]]:
-        """Fetch the credentials via repertoire."""
+        """Fetch the credentials via repertoire.
+
+        Parameters
+        ----------
+        auth
+            The username and password for authentication to repertoire
+            (RSP/gaefaelfwr token).
+        """
         creds_service = f"{API_ENDPOINTS[self.site]}/repertoire/discovery/influxdb"
         try:
             influx_creds = httpx.get(creds_service, auth=auth)
@@ -187,7 +194,8 @@ class InfluxQueryClient:
         time_range: tuple[Time, Time] | None = None,
         filters: list[tuple[str, str]] | None = None,
     ) -> str:
-        """Build an influx DB query.
+        """Build an influx DB query for `fields` from `measurement` (topic),
+        usually over a time range.
 
         Parameters
         ----------
@@ -235,7 +243,8 @@ class InfluxQueryClient:
         time_cut: Time | None = None,
         filters: list[tuple[str, str]] | None = None,
     ) -> str:
-        """Build an influx DB query.
+        """Build an influx DB query for `fields` from `measurement`,
+        restricted to `num` records.
 
         Parameters
         ----------
@@ -280,7 +289,18 @@ class InfluxQueryClient:
         return query
 
     def query(self, query: str) -> dict | pd.DataFrame:
-        """Send a synchronous query to the InfluxDB API."""
+        """Send and receive results from the InfluxDB API,
+        with a synchronous query.
+
+        Parameters
+        ----------
+        query
+            The query to send to the InfluxDb.
+
+        Returns
+        -------
+        result : `dict` or `pd.DataFrame`
+        """
         # Add an identifier string to the query
         params = {"db": self.db_name, "q": query + self.query_tag}
 
@@ -308,7 +328,19 @@ class InfluxQueryClient:
         return result
 
     async def async_query(self, query: str) -> dict | pd.DataFrame:
-        """Send an asynchronous query to the InfluxDB API."""
+        """Send and receive results from the InfluxDB API,
+        with an asynchronous query.
+
+        Parameters
+        ----------
+        query
+            The query to send to the InfluxDb.
+
+        Returns
+        -------
+        result : `dict` or `pd.DataFrame`
+        """
+
         params = {"db": self.db_name, "q": query}
         try:
             response = await self.async_client.get(
@@ -381,7 +413,9 @@ class InfluxQueryClient:
         t_end: Time,
         index: int | None = None,
     ) -> str:
-        """Return data from `topic_name` between `t_start` and `t_end`.
+        """Build specific query between t_start and t_end.
+
+        Adds some logging and checks around build_influxdb_query.
 
         Parameters
         ----------
@@ -419,7 +453,8 @@ class InfluxQueryClient:
         t_end: Time,
         index: int | None = None,
     ) -> pd.DataFrame | list[dict]:
-        """Return data from `topic_name` between `t_start` and `t_end`.
+        """Sync query to return data from `topic_name`
+        between `t_start` and `t_end`.
 
         Parameters
         ----------
@@ -451,7 +486,8 @@ class InfluxQueryClient:
         t_end: Time,
         index: int | None = None,
     ) -> pd.DataFrame | list[dict]:
-        """Return data from `topic_name` between `t_start` and `t_end`.
+        """Async query to return data from `topic_name`
+        between `t_start` and `t_end`.
 
         Parameters
         ----------
@@ -483,7 +519,9 @@ class InfluxQueryClient:
         time_cut: Time = None,
         index: int | None = None,
     ) -> str:
-        """Return data from `topic_name` between `t_start` and `t_end`.
+        """Build specific query for most recent `num` records.
+
+        Adds some logging and checks around build_influxdb_top_n_query.
 
         Parameters
         ----------
@@ -521,7 +559,7 @@ class InfluxQueryClient:
         time_cut: Time = None,
         index: int | None = None,
     ) -> pd.DataFrame | list[dict]:
-        """Return data from `topic_name` between `t_start` and `t_end`.
+        """Sync query to return `num` records from `topic_name`.
 
         Parameters
         ----------
@@ -553,7 +591,7 @@ class InfluxQueryClient:
         time_cut: Time = None,
         index: int | None = None,
     ) -> pd.DataFrame | list[dict]:
-        """Return data from `topic_name` between `t_start` and `t_end`.
+        """Async query to return `num` records from `topic_name`.
 
         Parameters
         ----------

--- a/rubin_nights/influx_query.py
+++ b/rubin_nights/influx_query.py
@@ -1,3 +1,4 @@
+import getpass
 import logging
 from functools import cache
 
@@ -5,6 +6,8 @@ import httpx
 import numpy as np
 import pandas as pd
 from astropy.time import Time
+
+from .reference_values import API_ENDPOINTS
 
 logger = logging.getLogger(__name__)
 
@@ -17,6 +20,10 @@ def day_obs_from_efd_index(x: pd.Series) -> int:
     return int(dayobs_time.isot.split("T")[0].replace("-", ""))
 
 
+class RepertoireCredsError(Exception):
+    pass
+
+
 class InfluxQueryClient:
     """Query for InfluxDB data such as EFD.
 
@@ -24,10 +31,24 @@ class InfluxQueryClient:
     ----------
     site
         The site to use for the EFD, e.g. usdf, summit, base.
-        Note: `usdf-dev` does not exist, and will be replaced with `usdf`.
+        Note that influxdb sites can be special: e.g. currently
+        the EFD at USDF is only on usdf-rsp (not -dev) and
+        Sasquatch (PP metrics) is only at usdf-rsp-dev.
     db_name
         The database to query.
+        Not used for credentials info, but will be used to help guide to the
+        correct location to fetch the credentials (usdf-int efd =>usdf efd).
         Default is "efd".
+    auth
+        The username and password for authentication to repertoire.
+        Note that *repertoire* auth is site-specific, even though
+        influx databases can be only available at one site (thus you may
+        need cross-site authentication). Also only usdf-rsp currently works.
+        If None, will fallback to segwarides.
+    id_tag
+        Add the service name or user name as a comment to the query.
+        This aids in tracking query sources in EFD logs.
+        If None, will be set to username.
     results_as_dataframe
         If True, convert query results into a pandas DataFrame.
         If False, results are returned as a list of dictionaries.
@@ -39,35 +60,93 @@ class InfluxQueryClient:
         self,
         site: str = "usdf",
         db_name: str = "efd",
+        auth: tuple | None = None,
+        id_tag: str | None = None,
         results_as_dataframe: bool = True,
         query_timeout: float = 5 * 60,
     ) -> None:
-        # On usdf-dev or usdf-int, still use 'usdf' as EFD endpoint.
-        if site == "usdf-dev" or site == "usdf-int":
-            site = "usdf"
-        self.site = site + "_efd"
+        # Fetching the credentials for the influx databases is as-yet complex.
+        # In addition, some databases are only in some influx locations.
+        # This can, in effect, require cross-platform auth to repertoire.
+        # Segwarides is the backup for repertoire.
         self.db_name = db_name
+
+        # Find DM/PP on usdfdev_efd
+        if ("prompt" in self.db_name) | ("dm" in self.db_name):
+            if "usdf" in site:
+                site = "usdf-dev"
+        # Find EFD and lsst.obsenv on usdf (but not -dev or -int).
+        else:
+            if "usdf" in site:
+                site = "usdf"
+        self.site = site
+
         self.results_as_dataframe = results_as_dataframe
         if self.results_as_dataframe:
             self.null_result = pd.DataFrame([])
         else:
             self.null_result = []
-        self.url, auth = self._fetch_credentials()
-        timeout = httpx.Timeout(query_timeout, connect=10.0)
-        self.httpx_client = httpx.Client(base_url=self.url, timeout=timeout, auth=auth)
-        self.async_client = httpx.AsyncClient(base_url=self.url, timeout=timeout, auth=auth)
 
-    def _fetch_credentials(self) -> tuple[str, tuple[str, bytes]]:
-        creds_service = f"https://roundtable.lsst.codes/segwarides/creds/{self.site}"
+        if id_tag is None:
+            id_tag = getpass.getuser()
+        self.query_tag = f" /* {id_tag} via rubin_nights.InfluxQueryClient */"
+
+        # Fetch the actual credentials: (only usdf-rsp works at present)
+        if self.site == "usdf" and auth is not None:
+            try:
+                self.url, influx_auth = self._fetch_credentials_repertoire(auth)
+            except RepertoireCredsError:
+                logger.error("Failed to fetch credentials from repertoire. Trying segwarides.")
+                self.url, influx_auth = self._fetch_credentials_segwarides()
+        else:
+            self.url, influx_auth = self._fetch_credentials_segwarides()
+
+        # Set up connections to influx database RestAPI endpoint.
+        timeout = httpx.Timeout(query_timeout, connect=10.0)
+        self.httpx_client = httpx.Client(base_url=self.url, timeout=timeout, auth=influx_auth)
+        self.async_client = httpx.AsyncClient(base_url=self.url, timeout=timeout, auth=influx_auth)
+
+    def _fetch_credentials_repertoire(self, auth: tuple) -> tuple[str, tuple[str, bytes]]:
+        """Fetch the credentials via repertoire."""
+        creds_service = f"{API_ENDPOINTS[self.site]}/repertoire/discovery/influxdb"
         try:
-            efd_creds = httpx.get(creds_service)
+            influx_creds = httpx.get(creds_service, auth=auth)
+            influx_creds.raise_for_status()
         except Exception as e:
-            logger.error(f"Could not fetch credentials for {self.site}")
+            logger.error(f"Could not fetch credentials from repertoire for {self.site}.")
             logger.error(e)
-            efd_creds.raise_for_status()
-        efd_creds = efd_creds.json()
-        auth = (efd_creds["username"], efd_creds["password"])
-        url = "https://" + efd_creds["host"] + efd_creds["path"].rstrip("/")
+            # This is almost certainly a mismatch between site + auth.
+            # e.g. looking for usdf EFD when coming from usdf-dev auth.
+            # or looking for usdfdev EFD when coming from usdf_rsp auth.
+            # Hard to avoid at present, will wait to see what square does.
+            raise RepertoireCredsError
+        # Parser the influx db credentials.
+        # Note that 'efd' is the only database name in use even for lsst.prompt
+        for k, v in influx_creds.json().items():
+            if v["database"] == "efd":
+                auth = (v["username"], v["password"])
+                url = v["url"]
+                logger.info(f"Fetched credentials from repertoire for {self.site}.")
+                return url, auth
+        # If we got here, we found no match or credentials.
+        logger.error(f"Could not find database in repertoire credentials for {self.site}.")
+        raise RepertoireCredsError
+
+    def _fetch_credentials_segwarides(self) -> tuple[str, tuple[str, bytes]]:
+        "Fetch the credentials via segwarides (to be deprecated)."
+        creds_service = f"https://roundtable.lsst.codes/segwarides/creds/{self.site.replace('-', '')}_efd"
+        try:
+            influx_creds = httpx.get(creds_service)
+            influx_creds.raise_for_status()
+        except Exception as e:
+            logger.error(f"Could not fetch credentials from segwarides for {self.site}")
+            logger.error(e)
+            raise e
+        # Parse the creds.
+        logger.info(f"Fetched credentials from segwarides for {self.site}.")
+        influx_creds = influx_creds.json()
+        auth = (influx_creds["username"], influx_creds["password"])
+        url = "https://" + influx_creds["host"] + influx_creds["path"].rstrip("/")
         return url, auth
 
     def __repr__(self) -> str:
@@ -202,14 +281,16 @@ class InfluxQueryClient:
 
     def query(self, query: str) -> dict | pd.DataFrame:
         """Send a synchronous query to the InfluxDB API."""
-        params = {"db": self.db_name, "q": query}
+        # Add an identifier string to the query
+        params = {"db": self.db_name, "q": query + self.query_tag}
+
         try:
             response = self.httpx_client.get(
                 "/query",
                 params=params,
             )
-            response.raise_for_status()
             logger.debug(f"Issued query: {params['q']}")
+            response.raise_for_status()
         except Exception as e:
             logger.warning(e)
             response = None

--- a/rubin_nights/influx_query.py
+++ b/rubin_nights/influx_query.py
@@ -65,21 +65,17 @@ class InfluxQueryClient:
         results_as_dataframe: bool = True,
         query_timeout: float = 5 * 60,
     ) -> None:
-        # Fetching the credentials for the influx databases is as-yet complex.
-        # In addition, some databases are only in some influx locations.
-        # This can, in effect, require cross-platform auth to repertoire.
-        # Segwarides is the backup for repertoire.
-        self.db_name = db_name
 
-        # Find DM/PP on usdfdev_efd
-        if ("prompt" in self.db_name) | ("dm" in self.db_name):
-            if "usdf" in site:
-                site = "usdf-dev"
-        # Find EFD and lsst.obsenv on usdf (but not -dev or -int).
-        else:
-            if "usdf" in site:
-                site = "usdf"
-        self.site = site
+        # Site should match general user-expectations and keys in API_ENDPOINTS
+        self.site = site.lower()
+        # db_name is the identifier when sending query params to the RESTAPI
+        self.db_name = db_name
+        # influx_db will be the name in repertoire for the influxdb
+        # so let's create that name from some potential values
+        # aka lsst.prompt @ usdf -> usdf_prompt
+        # aka efd @ usdf-dev -> usdfdev_efd
+        self.influx_db = f"{self.site.replace('-', '')}" + "_"
+        self.influx_db += f"{db_name.lower().replace("lsst.", "")}"
 
         self.results_as_dataframe = results_as_dataframe
         if self.results_as_dataframe:
@@ -91,14 +87,22 @@ class InfluxQueryClient:
             id_tag = getpass.getuser()
         self.query_tag = f" /* {id_tag} via rubin_nights.InfluxQueryClient */"
 
-        # Fetch the actual credentials: (only usdf-rsp works at present)
-        if self.site == "usdf" and auth is not None:
+        # For user convenience, save the last query.
+        self.last_query = "No query issued yet."
+
+        # Fetch the influxdb credentials.
+        if auth is not None:
             try:
                 self.url, influx_auth = self._fetch_credentials_repertoire(auth)
             except RepertoireCredsError:
                 logger.error("Failed to fetch credentials from repertoire. Trying segwarides.")
                 self.url, influx_auth = self._fetch_credentials_segwarides()
         else:
+            logger.warning(
+                "Fetching influx credentials from segwarides, "
+                "without an auth token will soon be deprecated. "
+                "Please add an auth tuple to your kwarg values."
+            )
             self.url, influx_auth = self._fetch_credentials_segwarides()
 
         # Set up connections to influx database RestAPI endpoint.
@@ -115,49 +119,57 @@ class InfluxQueryClient:
             The username and password for authentication to repertoire
             (RSP/gaefaelfwr token).
         """
-        creds_service = f"{API_ENDPOINTS[self.site]}/repertoire/discovery/influxdb"
+        creds_service = f"{API_ENDPOINTS[self.site]}/repertoire/discovery/influxdb/{self.influx_db}"
+        logger.debug(f"Attempting to fetch credentials from {creds_service}")
         try:
-            influx_creds = httpx.get(creds_service, auth=auth)
-            influx_creds.raise_for_status()
+            response = httpx.get(creds_service, auth=auth)
+            response.raise_for_status()
         except Exception as e:
-            logger.error(f"Could not fetch credentials from repertoire for {self.site}.")
+            logger.error(f"Could not fetch credentials from repertoire at {creds_service}.")
             logger.error(e)
-            # This is almost certainly a mismatch between site + auth.
-            # e.g. looking for usdf EFD when coming from usdf-dev auth.
-            # or looking for usdfdev EFD when coming from usdf_rsp auth.
-            # Hard to avoid at present, will wait to see what square does.
             raise RepertoireCredsError
-        # Parser the influx db credentials.
-        # Note that 'efd' is the only database name in use even for lsst.prompt
-        for k, v in influx_creds.json().items():
-            if v["database"] == "efd":
-                auth = (v["username"], v["password"])
-                url = v["url"]
-                logger.info(f"Fetched credentials from repertoire for {self.site}.")
-                return url, auth
-        # If we got here, we found no match or credentials.
-        logger.error(f"Could not find database in repertoire credentials for {self.site}.")
-        raise RepertoireCredsError
+
+        # Parse the influx db credentials.
+        try:
+            influx_creds = response.json()
+        except Exception as e:
+            logger.error(f"Could not parse credentials from repertoire at {creds_service}.")
+            logger.error(e)
+            raise RepertoireCredsError
+
+        auth = (influx_creds["username"], influx_creds["password"])
+        url = influx_creds["url"]
+        logger.info(f"Fetched credentials from repertoire for {self.influx_db}.")
+        return url, auth
 
     def _fetch_credentials_segwarides(self) -> tuple[str, tuple[str, bytes]]:
         "Fetch the credentials via segwarides (to be deprecated)."
-        creds_service = f"https://roundtable.lsst.codes/segwarides/creds/{self.site.replace('-', '')}_efd"
+        # Segwarides fallback is more complicated
+        if (self.influx_db == "usdf_efd") | (self.influx_db == "usdfdev_efd"):
+            segwarides_db = "usdf_efd"
+        elif self.influx_db == "usdf_obsenv":
+            segwarides_db = "usdf_efd"
+        else:
+            segwarides_db = "usdfdev_efd"
+        creds_service = f"https://roundtable.lsst.codes/segwarides/creds/{segwarides_db}"
         try:
-            influx_creds = httpx.get(creds_service)
-            influx_creds.raise_for_status()
+            response = httpx.get(creds_service)
+            response.raise_for_status()
         except Exception as e:
-            logger.error(f"Could not fetch credentials from segwarides for {self.site}")
+            logger.error(
+                f"Could not fetch credentials from segwarides for {self.influx_db} " f"using {segwarides_db}"
+            )
             logger.error(e)
             raise e
         # Parse the creds.
-        logger.info(f"Fetched credentials from segwarides for {self.site}.")
-        influx_creds = influx_creds.json()
+        logger.info(f"Fetched credentials from segwarides for {self.influx_db}.")
+        influx_creds = response.json()
         auth = (influx_creds["username"], influx_creds["password"])
         url = "https://" + influx_creds["host"] + influx_creds["path"].rstrip("/")
         return url, auth
 
     def __repr__(self) -> str:
-        return f"{self.db_name} at {self.url}"
+        return f"{self.influx_db} at {self.url}"
 
     def _to_dataframe(self, response: dict) -> pd.DataFrame:
         """Convert an InfluxDB response to a dataframe.
@@ -303,6 +315,7 @@ class InfluxQueryClient:
         """
         # Add an identifier string to the query
         params = {"db": self.db_name, "q": query + self.query_tag}
+        self.last_query = query + self.query_tag
 
         try:
             response = self.httpx_client.get(
@@ -340,8 +353,10 @@ class InfluxQueryClient:
         -------
         result : `dict` or `pd.DataFrame`
         """
-
+        # Add an identifier string to the query
         params = {"db": self.db_name, "q": query + self.query_tag}
+        self.last_query = query + self.query_tag
+
         try:
             response = await self.async_client.get(
                 "/query",

--- a/rubin_nights/pipelines_metrics.py
+++ b/rubin_nights/pipelines_metrics.py
@@ -29,7 +29,7 @@ def diasource_visit_summaries(
         This should be equivalent to the endpoints['sasquatch'] client.
     """
     if influx_client is None:
-        influx_client = InfluxQueryClient("usdfdev", db_name="lsst.prompt")
+        influx_client = InfluxQueryClient("usdf-dev", db_name="lsst.prompt")
 
     # DiaSources
     topic = "lsst.prompt.prod.numDiaSourcesGood"

--- a/tests/test_connections.py
+++ b/tests/test_connections.py
@@ -27,8 +27,9 @@ class TestConnections(unittest.TestCase):
         # Use the test tokenfile
         token = connections.get_access_token(tokenfile=self.tokenfile)
         self.assertEqual(token, self.expected_token)
-        # Use nothing (and use bad default_tokenfile
-        token = connections.get_access_token(default_tokenfile="NoToken")
+        # Use nothing
+        connections.DEFAULT_TOKENFILE = "dummy_token_does_not_exist"
+        token = connections.get_access_token()
         if os.getenv("EXTERNAL_INSTANCE_URL") is None:
             self.assertTrue(len(token) == 0)
         # This is expected to get a real token on the RSP
@@ -57,7 +58,16 @@ class TestConnections(unittest.TestCase):
             endpoints = connections.get_clients(tokenfile=tokenfile, site=site)
             self.assertTrue(isinstance(endpoints["api_base"], str))
         # Check expected clients are added to the dictionary
-        clients = ["consdb", "consdb_tap", "efd", "obsenv", "narrative_log", "exposure_log", "night_report"]
+        clients = [
+            "consdb",
+            "consdb_tap",
+            "efd",
+            "obsenv",
+            "pp",
+            "narrative_log",
+            "exposure_log",
+            "night_report",
+        ]
         endpoint_keys = list(endpoints.keys())
         self.assertTrue(len([c for c in clients if c not in endpoint_keys]) == 0)
 

--- a/tests/test_influx_query.py
+++ b/tests/test_influx_query.py
@@ -4,7 +4,7 @@ from unittest.mock import Mock, patch
 import pandas as pd
 from astropy.time import Time
 
-from rubin_nights.influx_query import InfluxQueryClient, RepertoireCredsError
+from rubin_nights.influx_query import InfluxQueryClient
 
 
 class DummyResponse:

--- a/tests/test_influx_query.py
+++ b/tests/test_influx_query.py
@@ -1,0 +1,200 @@
+import unittest
+from unittest.mock import Mock, patch
+
+import pandas as pd
+from astropy.time import Time
+
+from rubin_nights.influx_query import InfluxQueryClient, RepertoireCredsError
+
+
+class DummyResponse:
+    def __init__(self, payload: dict, status_code: int = 200) -> None:
+        self._payload = payload
+        self.status_code = status_code
+
+    def json(self) -> dict:
+        return self._payload
+
+    def raise_for_status(self) -> None:
+        return None
+
+
+class TestInfluxQueryClient(unittest.TestCase):
+
+    def setUp(self) -> None:
+        self.repertoire_payload = {
+            "efd": {
+                "database": "efd",
+                "username": "user1",
+                "password": "pass1",
+                "url": "https://example.test/influx",
+            }
+        }
+        self.segwarides_payload = {
+            "username": "user2",
+            "password": "pass2",
+            "host": "seg.test",
+            "path": "/influx/",
+        }
+
+    @patch("rubin_nights.influx_query.httpx.AsyncClient")
+    @patch("rubin_nights.influx_query.httpx.Client")
+    @patch("rubin_nights.influx_query.httpx.get")
+    def test_init_uses_repertoire_for_usdf_with_auth(self, mock_get, mock_client, mock_async_client) -> None:
+        mock_get.return_value = DummyResponse(self.repertoire_payload)
+
+        client = InfluxQueryClient("usdf", db_name="efd", auth=("auth_user", "dummy_token"))
+
+        self.assertEqual(client.site, "usdf")
+        self.assertEqual(client.url, "https://example.test/influx")
+        mock_get.assert_called_once()
+        mock_client.assert_called_once()
+        mock_async_client.assert_called_once()
+
+    @patch("rubin_nights.influx_query.httpx.AsyncClient")
+    @patch("rubin_nights.influx_query.httpx.Client")
+    @patch("rubin_nights.influx_query.httpx.get")
+    def test_init_falls_back_to_segwarides_on_repertoire_error(
+        self, mock_get, mock_client, mock_async_client
+    ) -> None:
+        mock_get.side_effect = [
+            Exception("boom"),
+            DummyResponse(self.segwarides_payload),
+        ]
+
+        client = InfluxQueryClient("usdf", db_name="efd", auth=("auth_user", "dummy_token"))
+
+        self.assertEqual(client.site, "usdf")
+        self.assertEqual(client.url, "https://seg.test/influx")
+
+    def test_build_influxdb_query(self) -> None:
+        start = Time("2025-01-01T00:00:00", scale="utc")
+        end = Time("2025-01-01T01:00:00", scale="utc")
+
+        query = InfluxQueryClient.build_influxdb_query(
+            "my_measurement",
+            fields=["a", "b"],
+            time_range=(start, end),
+            filters=[("salIndex", "1")],
+        )
+
+        self.assertEqual(
+            query,
+            "SELECT a, b FROM \"my_measurement\" WHERE time >= '2025-01-01T00:00:00.000Z' "
+            "AND time <= '2025-01-01T01:00:00.000Z' AND salIndex = 1",
+        )
+
+    def test_build_influxdb_top_n_query(self) -> None:
+        cut = Time("2025-01-01T00:00:00", scale="utc")
+
+        query = InfluxQueryClient.build_influxdb_top_n_query(
+            "my_measurement",
+            fields="a",
+            num=5,
+            time_cut=cut,
+            filters=[("salIndex", "2")],
+        )
+
+        self.assertEqual(
+            query,
+            "SELECT a FROM \"my_measurement\" WHERE time <= '2025-01-01T00:00:00.000Z' "
+            "AND salIndex = 2 GROUP BY * ORDER BY DESC LIMIT 5",
+        )
+
+    def test_to_dataframe_with_time_tags_and_name(self) -> None:
+        client = object.__new__(InfluxQueryClient)
+        response = {
+            "results": [
+                {
+                    "series": [
+                        {
+                            "name": "topic_name",
+                            "columns": ["time", "value"],
+                            "values": [["2025-01-01T00:00:00Z", 42]],
+                            "tags": {"site": "usdf"},
+                        }
+                    ]
+                }
+            ]
+        }
+
+        df = InfluxQueryClient._to_dataframe(client, response)
+
+        self.assertIsInstance(df, pd.DataFrame)
+        self.assertEqual(list(df.columns), ["value", "site"])
+        self.assertEqual(df.iloc[0]["value"], 42)
+        self.assertEqual(df.iloc[0]["site"], "usdf")
+        self.assertEqual(df.name, "topic_name")
+        self.assertIsNotNone(df.index.tz)
+
+    def test_to_dataframe_zero_results(self) -> None:
+        client = object.__new__(InfluxQueryClient)
+        response = {"results": [{}]}
+        df = InfluxQueryClient._to_dataframe(client, response)
+        self.assertTrue(df.empty)
+
+    @patch("rubin_nights.influx_query.httpx.AsyncClient")
+    @patch("rubin_nights.influx_query.httpx.Client")
+    @patch.object(
+        InfluxQueryClient, "_fetch_credentials_segwarides", return_value=("https://example.test", ("u", "p"))
+    )
+    def test_query_returns_dataframe(self, mock_creds, mock_client, mock_async_client) -> None:
+        mock_response = Mock()
+        mock_response.json.return_value = {
+            "results": [
+                {
+                    "series": [
+                        {
+                            "name": "topic_name",
+                            "columns": ["time", "value"],
+                            "values": [["2025-01-01T00:00:00Z", 1]],
+                        }
+                    ]
+                }
+            ]
+        }
+        mock_response.raise_for_status.return_value = None
+        mock_client.return_value.get.return_value = mock_response
+
+        client = InfluxQueryClient("summit", db_name="efd", results_as_dataframe=True)
+        result = client.query("show measurements")
+
+        self.assertIsInstance(result, pd.DataFrame)
+        self.assertEqual(result.iloc[0]["value"], 1)
+
+    @patch("rubin_nights.influx_query.httpx.AsyncClient")
+    @patch("rubin_nights.influx_query.httpx.Client")
+    @patch.object(
+        InfluxQueryClient, "_fetch_credentials_segwarides", return_value=("https://example.test", ("u", "p"))
+    )
+    def test_query_returns_list_when_not_dataframe(self, mock_creds, mock_client, mock_async_client) -> None:
+        mock_response = Mock()
+        payload = {"results": [{"series": [{"columns": ["name"], "values": [["m1"]]}]}]}
+        mock_response.json.return_value = payload
+        mock_response.raise_for_status.return_value = None
+        mock_client.return_value.get.return_value = mock_response
+
+        client = InfluxQueryClient("summit", db_name="efd", results_as_dataframe=False)
+        result = client.query("show measurements")
+
+        self.assertEqual(result, payload)
+
+    @patch("rubin_nights.influx_query.httpx.AsyncClient")
+    @patch("rubin_nights.influx_query.httpx.Client")
+    @patch.object(
+        InfluxQueryClient, "_fetch_credentials_segwarides", return_value=("https://example.test", ("u", "p"))
+    )
+    def test_get_topics_caches_result(self, mock_creds, mock_client, mock_async_client) -> None:
+        client = InfluxQueryClient("summit", db_name="efd")
+        client.query = Mock(return_value=pd.DataFrame({"name": ["m1", "m2"]}))
+
+        first = client.get_topics()
+        second = client.get_topics()
+
+        self.assertEqual(first, ["m1", "m2"])
+        self.assertEqual(second, ["m1", "m2"])
+        self.assertEqual(client.query.call_count, 1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_influx_query.py
+++ b/tests/test_influx_query.py
@@ -23,12 +23,10 @@ class TestInfluxQueryClient(unittest.TestCase):
 
     def setUp(self) -> None:
         self.repertoire_payload = {
-            "efd": {
-                "database": "efd",
-                "username": "user1",
-                "password": "pass1",
-                "url": "https://example.test/influx",
-            }
+            "database": "efd",
+            "username": "user1",
+            "password": "pass1",
+            "url": "https://example.test/influx",
         }
         self.segwarides_payload = {
             "username": "user2",


### PR DESCRIPTION
For some influx services, repertoire is now available and preferred for authentication, rather than segwarides. 
Note that this really is only usable (on-the-fly)  right now with the standard EFD influx db on usdf-rsp, using usdf-rsp tokens that have added the scope for `read:sasquatch`.  
(i.e. using an usdf-rsp-dev token will not work to fetch EFD credentials; using an usdf-rsp token will not work to fetch usdfdev EFD credentials for lsst.prompt, etc -- and the usdf-rsp-dev access tokens do not yet have the read:sasquatch scope available, although the relevant repertoire page reachable directly if logged into usdf-rsp-dev). 

This PR also adds an identifier string to the end of each influx query - it will be a user-supplied "id tag" (or their username, if not set) + 'via rubin_nights.InfluxQueryClient' . 

I realize there will be additional changes needed as the setup for repertoire expands, in particular to handle the usdf-rsp vs. usdf-rsp-dev split. 