### PR TITLE
U/lynnej/better query explogs

### DIFF
--- a/rubin_nights/logging_query.py
+++ b/rubin_nights/logging_query.py
@@ -533,8 +533,10 @@ class ExposureLogClient(LoggingServiceClient):
         ----------
         t_start
             Time of start of exposure log query.
+            This is translated to min_day_obs for the query.
         t_end
             Time of end of exposure log query.
+            This is translated to max_day_obs for the query.
         user_params
             Additional parameters to add or override defaults.
             Passing `{'limit': int}` can override the default limit.
@@ -542,13 +544,21 @@ class ExposureLogClient(LoggingServiceClient):
         Returns
         -------
         params : `dict`
+
+        Notes
+        -----
+        The exposure log contains the day_obs and seq_num for the exposure
+        records, as well as date_added. It does not contain the time
+        of the exposure itself directly. Thus t_start and t_end are translated
+        to less specific min_day_obs_min and max_day_obs for the query.
         """
         log_limit = 50000
+
         params = {
             "is_human": "either",
             "is_valid": "true",
-            "min_date_added": t_start.to_datetime(),
-            "max_date_added": t_end.to_datetime(),
+            "min_day_obs": int(t_start.tai.isot.split("T")[0].replace("-", "")),
+            "max_day_obs": int(t_end.tai.isot.split("T")[0].replace("-", "")),
             "limit": log_limit,
         }
         if user_params is not None:

--- a/rubin_nights/observatory_status.py
+++ b/rubin_nights/observatory_status.py
@@ -7,7 +7,13 @@ from astropy.time import Time
 from .dayobs_utils import day_obs_sunset_sunrise
 from .influx_query import InfluxQueryClient, day_obs_from_efd_index
 
-__all__ = ["get_dome_open_close", "mtm1m3_slewflag_times", "get_rotator_limits", "get_tma_limits"]
+__all__ = [
+    "get_dome_open_close",
+    "mtm1m3_slewflag_times",
+    "get_rotator_limits",
+    "get_tma_limits",
+    "get_mounted_bandpasses",
+]
 
 logger = logging.getLogger(__name__)
 
@@ -103,8 +109,8 @@ def get_dome_open_close(
         close_start = None
         if len(closing) > 0:
             # Pick out the dome closing events that are first in each
-            # 5 minute interval (separate dome closing events).
-            gaps = np.where((np.diff(closing.index) / pd.Timedelta(1, "s")) > 5 * 60)[0]
+            # 3 minute interval (separate dome closing events).
+            gaps = np.where((np.diff(closing.index) / pd.Timedelta(1, "s")) > 3 * 60)[0]
             gaps += 1
             gaps = np.concatenate([np.array([0]), gaps])
             close_start = Time(closing.iloc[gaps].index.values, scale="utc").utc.datetime
@@ -358,3 +364,24 @@ def get_tma_limits(t_start: Time, t_end: Time, efd_client: InfluxQueryClient) ->
     tma.ffill(axis=0, inplace=True)
     tma.query("index >= @index_edges[0] and index <= @index_edges[1]", inplace=True)
     return tma
+
+
+def get_mounted_bandpasses(t_start: Time, t_end: Time, efd_client: InfluxQueryClient) -> pd.DataFrame:
+    topic = "lsst.sal.MTCamera.logevent_availableFilters"
+    # Find starting value
+    bands_start = efd_client.select_top_n(topic, ["filterTypes"], num=1, time_cut=t_start)
+    bands_during = efd_client.select_time_series(topic, ["filterTypes"], t_start, t_end)
+    bands = pd.concat([bands_start, bands_during])
+    bands.rename(columns={"filterTypes": "available_bands"}, inplace=True)
+    bands.sort_index(inplace=True)
+
+    # Reformat string of bandpass names to list, dropping "none"
+    def parse_available_bands(x: pd.Series) -> pd.Series:
+        return [
+            f'"{band.strip()}"'
+            for band in x.available_bands.split(",")
+            if band.strip() and band.strip().lower() != "none"
+        ]
+
+    bands["available_bands"] = bands.apply(parse_available_bands, axis=1)
+    return bands

--- a/rubin_nights/scriptqueue.py
+++ b/rubin_nights/scriptqueue.py
@@ -100,9 +100,8 @@ def get_scheduler_configs(
 
     def build_link_to_config(x: pd.Series) -> str:
         desc_string = f"{x.config_yaml}  <br> {x.config_repo} {x.config_commit}"
-        link = (
-            f"https://github.com/lsst-ts/{x.config_repo}/tree/{x.config_commit}/Scheduler/v9/{x.config_yaml}"
-        )
+        link = f"https://github.com/lsst-ts/{x.config_repo}/tree/"
+        link += f"{x.config_commit}/Scheduler/{x.schemaVersion}/{x.config_yaml}"
         url = f'<a href="{link}" target="_blank" rel="noreferrer noopener">{desc_string}</a>'
         return url
 

--- a/rubin_nights/scriptqueue.py
+++ b/rubin_nights/scriptqueue.py
@@ -101,7 +101,7 @@ def get_scheduler_configs(
     def build_link_to_config(x: pd.Series) -> str:
         desc_string = f"{x.config_yaml}  <br> {x.config_repo} {x.config_commit}"
         link = (
-            f"https://github.com/lsst-ts/{x.config_repo}/tree/{x.config_commit}/Scheduler/v8/{x.config_yaml}"
+            f"https://github.com/lsst-ts/{x.config_repo}/tree/{x.config_commit}/Scheduler/v9/{x.config_yaml}"
         )
         url = f'<a href="{link}" target="_blank" rel="noreferrer noopener">{desc_string}</a>'
         return url
@@ -994,6 +994,9 @@ def get_exposure_info(
             axis=1,
             inplace=True,
         )
+        idx = exp_logs.query("finalStatus == 'none'").index
+        exp_logs.loc[idx, "finalStatus"] = ""
+        exp_logs["finalStatus"] = "ExpLog " + exp_logs["finalStatus"]
         image_acquisition = pd.concat([image_acquisition, exp_logs]).sort_index()
         logger.info("Joined exposure and exposure log")
     return image_acquisition


### PR DESCRIPTION
The exposure logs lately have been added after the fact, so querying for logs from a given dayobs period doesn't work as intended in the script queue -- the exposure log service only allows dayobs or time_added queries, but not "time of exposure" queries.  Before this update, I was querying based on time_added and assuming it would be in the right time span, but this is not always the case lately. Thus -- update to query for a given dayobs range (which is a slightly expanded timespan) given t_start and t_end. Works better, not perfect. 

Also added a function to query for the mounted bandpasses in a format that would easily fit into the rubin_scheduler bandpass scheduler function. 