### PR TITLE
OSW-2404: Avoid idle postgres transactions.

### DIFF
--- a/rubin_nights/consdb_query.py
+++ b/rubin_nights/consdb_query.py
@@ -426,10 +426,8 @@ class ConsDbSql(ConsDb):
             self.conn_str = connection_string
 
         self.engine = sqlalchemy.create_engine(self.conn_str)
-        self.conn = self.engine.connect()
 
     def __del__(self) -> None:
-        self.conn.close()
         self.engine.dispose()
 
     def __repr__(self) -> str:
@@ -447,10 +445,13 @@ class ConsDbSql(ConsDb):
         -------
         results : `pd.DataFrame`
         """
+        # engine.begin() opens a transaction scoped to this query and commits
+        # on success or rolls back on error, so no connection is left idle in
+        # transaction once the query returns.
         try:
-            result = pd.read_sql(query, self.conn)
+            with self.engine.begin() as conn:
+                result = pd.read_sql(query, conn)
         except ProgrammingError as e:
-            self.conn.rollback()
             logger.error(e)
             result = pd.DataFrame([])
         return result


### PR DESCRIPTION
Fixes a connection left idle in transaction on the Postgres server by ConsDbSql. Previously the class held a single long-lived connection and never commited or rolled back after a successful SELECT, so under sqlalchemy the transaction stayed open. If a pod is left with a notebook running with ConsDbSql instance, the transaction will live as long as the pod. Each query() now runs inside an engine.begin() block that commits on success and rolls back on error, so no transaction is left open once the query returns.